### PR TITLE
Clean unused imports

### DIFF
--- a/tests/data_integrity/test_value_ranges.py
+++ b/tests/data_integrity/test_value_ranges.py
@@ -1,6 +1,3 @@
-import numpy as np
-
-
 def test_gdp_values_positive(raw_df):
     assert (raw_df["GDP_USD"].dropna() > 0).all()
 

--- a/tests/processor/test_capital.py
+++ b/tests/processor/test_capital.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pandas as pd
 
-from utils.capital import calculate_capital_stock, project_capital_stock
+from utils.capital import calculate_capital_stock
 
 
 def test_calculate_capital_stock_missing():

--- a/tests/processor/test_extrapolation.py
+++ b/tests/processor/test_extrapolation.py
@@ -1,6 +1,5 @@
 """Tests for time series extrapolation functionality."""
 
-from unittest import mock
 
 import pandas as pd
 
@@ -29,9 +28,6 @@ def test_extrapolate_series_to_end_year(monkeypatch):
         def forecast(self, steps):
             return [1.0] * steps
 
-    # Import the modules where ARIMA and LinearRegression are used
-    import utils.extrapolation_methods.arima as arima_module
-    import utils.extrapolation_methods.linear_regression as linear_regression_module
 
     # Mock the extrapolation functions to return successful results
     def mock_extrapolate_with_arima(df, col, years, **kwargs):

--- a/tests/processor/test_human_capital.py
+++ b/tests/processor/test_human_capital.py
@@ -1,6 +1,5 @@
 """Tests for human capital projection."""
 
-from unittest import mock
 
 import numpy as np
 import pandas as pd

--- a/tests/processor/test_loading.py
+++ b/tests/processor/test_loading.py
@@ -1,9 +1,6 @@
 """Tests for data loading functionality."""
 
 import os
-from unittest import mock
-
-import pandas as pd
 import pytest
 
 from utils.processor_load import load_raw_data

--- a/tests/processor/test_output.py
+++ b/tests/processor/test_output.py
@@ -1,7 +1,5 @@
 """Tests for output file generation."""
 
-import os
-
 import pandas as pd
 
 from utils.output import create_markdown_table

--- a/tests/processor/test_processed_properties.py
+++ b/tests/processor/test_processed_properties.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import pandas as pd
-import pytest
 
 
 def test_processed_data_properties():

--- a/tests/test_dataframe_ops.py
+++ b/tests/test_dataframe_ops.py
@@ -1,5 +1,3 @@
-import os
-
 import pandas as pd
 
 from utils.processor_dataframe import merge_dataframe_column, merge_projections, merge_tax_data, prepare_final_dataframe

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -7,12 +7,6 @@ This module tests the data downloading functionality including:
 - Data format validation
 """
 
-import builtins
-import io
-import os
-import types
-from unittest import mock
-
 import pandas as pd
 import pytest
 

--- a/tests/test_imf_loader.py
+++ b/tests/test_imf_loader.py
@@ -1,6 +1,4 @@
-from unittest.mock import MagicMock, mock_open, patch
-
-import numpy as np
+from unittest.mock import mock_open, patch
 import pandas as pd
 import pytest
 

--- a/tests/test_integration_processor.py
+++ b/tests/test_integration_processor.py
@@ -1,9 +1,8 @@
 import os
 import shutil
 import tempfile
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import mock_open, patch
 
-import numpy as np
 import pandas as pd
 import pytest
 

--- a/tests/test_path_constants.py
+++ b/tests/test_path_constants.py
@@ -1,7 +1,4 @@
 import os
-from unittest.mock import MagicMock, patch
-
-import pytest
 
 from utils.path_constants import INPUT_DIR_NAME, OUTPUT_DIR_NAME, get_search_locations_relative_to_root
 

--- a/tests/test_pwt_downloader.py
+++ b/tests/test_pwt_downloader.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pandas as pd
 import pytest

--- a/tests/test_wdi_downloader.py
+++ b/tests/test_wdi_downloader.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from unittest import mock
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd

--- a/utils/data_sources/fallback_loader.py
+++ b/utils/data_sources/fallback_loader.py
@@ -13,7 +13,6 @@ import pandas as pd
 
 from config import Config
 from utils.error_handling import DataValidationError, FileOperationError, log_error_with_context
-from utils.validation_utils import INDICATOR_VALIDATION_RULES, validate_dataframe_with_rules
 
 logger = logging.getLogger(__name__)
 

--- a/utils/data_sources/imf_loader.py
+++ b/utils/data_sources/imf_loader.py
@@ -2,7 +2,6 @@ import hashlib
 import logging
 import os
 from datetime import datetime
-from typing import Any, Dict
 
 import pandas as pd
 

--- a/utils/processor_hc.py
+++ b/utils/processor_hc.py
@@ -6,7 +6,6 @@ using various statistical methods.
 """
 
 import logging
-from typing import Union
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
## Summary
- remove unused imports across tests and utils

## Testing
- `ruff check . --select F401`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*