### PR TITLE
Fix lints in tests and utils

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -9,7 +9,6 @@ This module tests the data downloading functionality including:
 
 import builtins
 import io
-import os
 import types
 from unittest import mock
 

--- a/tests/test_economic_indicators.py
+++ b/tests/test_economic_indicators.py
@@ -234,7 +234,7 @@ class TestCalculateEconomicIndicators:
         """Test that custom logger is used when provided."""
         mock_logger = MagicMock()
 
-        result = calculate_economic_indicators(complete_data, logger=mock_logger)
+        calculate_economic_indicators(complete_data, logger=mock_logger)
 
         # Logger should have been called
         assert mock_logger.info.called

--- a/tests/test_imf_loader.py
+++ b/tests/test_imf_loader.py
@@ -128,7 +128,7 @@ class TestIMFLoader:
         result = check_and_update_hash()
 
         # Should return True (hash was updated)
-        assert result == True
+        assert result is True
 
     @patch("utils.data_sources.imf_loader.find_file")
     def test_check_and_update_hash_no_imf_file(self, mock_find_file):
@@ -138,4 +138,4 @@ class TestIMFLoader:
         result = check_and_update_hash()
 
         # Should return False
-        assert result == False
+        assert result is False

--- a/utils/data_sources/wdi_downloader.py
+++ b/utils/data_sources/wdi_downloader.py
@@ -51,7 +51,7 @@ def download_wdi_data(
             reader.timeout = Config.REQUEST_TIMEOUT_SECONDS
             raw_data = reader.read()
             reader.close()
-            
+
             # Convert to DataFrame explicitly
             data = pd.DataFrame(raw_data) if raw_data is not None else pd.DataFrame()
 

--- a/utils/output/__init__.py
+++ b/utils/output/__init__.py
@@ -1,7 +1,7 @@
 """
 Output processing utilities for China data processor.
 
-This package provides functionality for formatting data and generating 
+This package provides functionality for formatting data and generating
 various output formats (markdown, CSV, etc.).
 """
 


### PR DESCRIPTION
## Summary
- fix True/False comparison in IMF loader tests
- clean whitespace in WDI downloader and utils output
- remove unused os import in downloader tests
- drop unused variable in economic indicators test

## Testing
- `black tests/test_imf_loader.py utils/data_sources/wdi_downloader.py utils/output/__init__.py tests/test_downloader.py tests/test_economic_indicators.py`
- `isort tests/test_imf_loader.py utils/data_sources/wdi_downloader.py utils/output/__init__.py tests/test_downloader.py tests/test_economic_indicators.py`
- `make lint` *(fails: flake8 not found)*
- `make test` *(fails: ModuleNotFoundError: No module named 'numpy')*