### PR TITLE
Fix LaTeX escapes in markdown template

### DIFF
--- a/utils/output/markdown_generator.py
+++ b/utils/output/markdown_generator.py
@@ -120,7 +120,7 @@ def create_markdown_table(
 
     today = datetime.today().strftime("%Y-%m-%d")
     tmpl = Template(
-        """# Processed China Economic Data
+        r"""# Processed China Economic Data
 
 |{% for h in headers %} {{ h }} |{% endfor %}
 |{% for h in headers %}---|{% endfor %}


### PR DESCRIPTION
## Summary
- make the markdown template a raw string so LaTeX backslashes are preserved

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*