### PR TITLE
Fix Dockerfile permission for container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ COPY --from=builder /app/.venv /app/.venv
 # Copy application code
 COPY --chown=app:app . .
 
+# Ensure ownership of the application directory
+RUN chown -R app:app /app
+
 # Switch to non-root user
 USER app
 


### PR DESCRIPTION
## Summary
- ensure `/app` directory is owned by the `app` user before switching users

## Testing
- `ruff check Dockerfile`
- `ruff format Dockerfile` *(fails: Failed to parse Dockerfile)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_factoryboy')*